### PR TITLE
Change `bind` to `live` so AJAX’d close links work?

### DIFF
--- a/jquery.lightbox_me.js
+++ b/jquery.lightbox_me.js
@@ -90,7 +90,7 @@
                      .scroll(setSelfPosition)
                      .keydown(observeEscapePress);
                      
-            $self.find(opts.closeSelector).click(function() { removeModal(true); return false; });
+            $self.find(opts.closeSelector).live('click', function() { removeModal(true); return false; });
             $overlay.click(function() { if(opts.closeClick){ removeModal(true); return false;} });
 
             
@@ -117,7 +117,7 @@
                     opts.destroyOnClose ? $self.remove() : $self.hide()
                     
                     
-                    $self.find(opts.closeSelector).unbind('click');
+                    $self.find(opts.closeSelector).die('click');
                     $self.unbind('close');
                     $self.unbind('resize');
                     $(window).unbind('scroll', setSelfPosition);


### PR DESCRIPTION
First off, thank you for building this plugin. It is easy to use and customize and works well. I recently ran into a situation where I needed to make a change that you may want. Sometimes the contents of the modal will change — close link and all — through a combination of user interaction/AJAX and technical requirements. As such, if a new close link is added to the modal, it does not have the event bound to it to close the modal. Using `live` binds the event to all elements that do now and will yet appear, and thus solves the problem.

Let me know what you think.

--Ben Spaulding
