### PR TITLE
live event for click on close 

### DIFF
--- a/jquery.lightbox_me.js
+++ b/jquery.lightbox_me.js
@@ -90,7 +90,7 @@
                      .scroll(setSelfPosition)
                      .keydown(observeEscapePress);
                      
-            $self.find(opts.closeSelector).click(function() { removeModal(true); return false; });
+            $self.find(opts.closeSelector).live('click', function() { removeModal(true); return false; });
             $overlay.click(function() { if(opts.closeClick){ removeModal(true); return false;} });
 
             


### PR DESCRIPTION
When I use Ajax to load a lightbox (and create DOM in it), I need the click on closeSelector event to be live to work.
