### PR TITLE
Fix: multiple close events being triggered

### DIFF
--- a/jquery.lightbox_me.js
+++ b/jquery.lightbox_me.js
@@ -92,8 +92,10 @@
 
             $(window).resize(setOverlayHeight)
                      .resize(setSelfPosition)
-                     .scroll(setSelfPosition)
-                     .keyup(observeKeyPress);
+                     .scroll(setSelfPosition);
+                     
+            $(window).bind('keyup.lightbox_me', observeKeyPress);
+                     
             if (opts.closeClick) {
                 $overlay.click(function(e) { closeLightbox(); e.preventDefault; });
             }
@@ -135,7 +137,7 @@
                 $(window).unbind('reposition', setOverlayHeight);
                 $(window).unbind('reposition', setSelfPosition);
                 $(window).unbind('scroll', setSelfPosition);
-                $(document).unbind('keyup', observeKeyPress);
+                $(window).unbind('keyup.lightbox_me');
                 if (ie6)
                     s.removeExpression('top');
                 opts.onClose();


### PR DESCRIPTION
When adding a new lightbox, make sure we unbind the keyup from the window (not the document)

This was causing additional unwanted onClose events to be called each time you hit 'escape' (once per lightbox load, which add up eventually)
