### PR TITLE
Allow modalCSS options even if centered

### DIFF
--- a/jquery.lightbox_me.js
+++ b/jquery.lightbox_me.js
@@ -207,7 +207,7 @@
                         }
                     } else {
                         if (opts.centered) {
-                            $self.css({ position: 'fixed', top: '50%', marginTop: ($self.outerHeight() / 2) * -1})
+                            $self.css({ position: 'fixed'}).css(opts.modalCSS).css({ top: '50%', marginTop: ($self.outerHeight() / 2) * -1});
                         } else {
                             $self.css({ position: 'fixed'}).css(opts.modalCSS);
                         }


### PR DESCRIPTION
This allows modalCSS options to work while still preserving the center-option-overriding-modalCSS idea.
